### PR TITLE
Improvement/add active on anchor

### DIFF
--- a/src/app/components/page/styles/anchor-menu.scss
+++ b/src/app/components/page/styles/anchor-menu.scss
@@ -45,7 +45,9 @@
         padding-bottom: 6rem;
       }
 
-      &:hover,
+      &:hover{
+        color: var(--sdds-grey-600);
+      }
       &:active,
       &.active {
         color: var(--sdds-blue-900);

--- a/src/app/components/page/tab-content/tab-content.component.html
+++ b/src/app/components/page/tab-content/tab-content.component.html
@@ -5,7 +5,7 @@
         <ng-container *ngFor="let section of item.content.section">
           <li *ngIf='section.Title'>
             <a [routerLink]="defaultTab" (click)='anchorMenu(section.Title)' [fragment]='section.Title | generateTabUrl'
-            class="sdds-text-grey-400" [ngClass]="isAnchorActive ? 'active' : ''">{{section.Title}}</a>
+            class="sdds-text-grey-400" [ngClass]="{'active': isAnchorActive === generateUrl(section.Title)}">{{section.Title}}</a>
           </li>
         </ng-container>
       </ul>

--- a/src/app/components/page/tab-content/tab-content.component.html
+++ b/src/app/components/page/tab-content/tab-content.component.html
@@ -4,7 +4,8 @@
       <ul>
         <ng-container *ngFor="let section of item.content.section">
           <li *ngIf='section.Title'>
-            <a [routerLink]="defaultTab" (click)='anchorMenu(section.Title)' [fragment]='section.Title | generateTabUrl' class="sdds-text-grey-400">{{section.Title}}</a>
+            <a [routerLink]="defaultTab" (click)='anchorMenu(section.Title)' [fragment]='section.Title | generateTabUrl'
+            class="sdds-text-grey-400" [ngClass]="isAnchorActive ? 'active' : ''">{{section.Title}}</a>
           </li>
         </ng-container>
       </ul>
@@ -75,7 +76,7 @@
         <!-- Two column -->
         <ng-template [ngIf]="section.__typename === 'ComponentContentPluginTwoColumns'">
           <div class="sdds-col-xlg-16 sdds-col-md-8 sdds-col-sm-4">
-            <h4 *ngIf='section.Title' [innerHTML]='section.Title | markdown | keepHtml' [id]='section.Title | generateTabUrl'></h4>
+            <h4 *ngIf='section.Title' [innerHTML]='section.Title | markdown | keepHtml' [id]='section.Title | generateTabUrl' class="section-title"></h4>
           </div>
 
           <div class="sdds-col-xlg-8 sdds-col-md-4 sdds-col-sm-4">
@@ -93,7 +94,7 @@
         <!-- Multiple columns-->
         <ng-template [ngIf]="section.__typename === 'ComponentContentPluginTwoColumnsImages'">
           <div class="no-padding sdds-multi-col-plugin sdds-col-xxlg-9 sdds-col-xlg-11 sdds-col-lg-6 sdds-col-md-8 sdds-col-sm-4">
-            <h4 *ngIf='section.Title' [innerHTML]='section.Title | markdown | keepHtml' [id]='section.Title | generateTabUrl'></h4>
+            <h4 *ngIf='section.Title' [innerHTML]='section.Title | markdown | keepHtml' [id]='section.Title | generateTabUrl' class="section-title"></h4>
           </div>
 
             <!-- If texts -->
@@ -164,7 +165,7 @@
           <div class="row RightImage">
 
             <div class='col-md-6'>
-              <h2 *ngIf='section.title' [innerHTML]='section.title | markdown | keepHtml'></h2>
+              <h4 *ngIf='section.title' [innerHTML]='section.title | markdown | keepHtml' class="section-title"></h4>
               <div class="row">
                 <div *ngFor="let paragraph of section.Paragraphs" [ngClass]="{'col-md-12': paragraph.Columns == 'One', 'col-md-6': paragraph.Columns == 'Two', 'col-md-3': paragraph.Columns == 'Three'}">
                   <div *ngIf='paragraph.textfield' [innerHTML]='paragraph.textfield | markdown | keepHtml'></div>

--- a/src/app/components/page/tab-content/tab-content.component.ts
+++ b/src/app/components/page/tab-content/tab-content.component.ts
@@ -87,10 +87,8 @@ export class TabContentComponent implements OnInit, AfterViewChecked {
   }
 
   onScroll(e){
-    const pos = Math.round(e.target.scrollTop);
-    
     this.titleElements.forEach(title => {
-      if(title.offset <= (pos - this.pageOffset)) this.isAnchorActive = title.id;
+      if(title.offset <= this.pageOffset + 50) this.isAnchorActive = title.id;
     })
   }
 

--- a/src/app/components/page/tab-content/tab-content.component.ts
+++ b/src/app/components/page/tab-content/tab-content.component.ts
@@ -1,5 +1,5 @@
-import { AfterViewInit, Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { AfterViewChecked, Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router} from '@angular/router';
 
 import { PageService } from 'src/app/app.service';
 import { Page } from 'src/app/app.interface';
@@ -13,7 +13,7 @@ import { menus } from '../../../data/content.json';
   host: { class: 'tab-component-container' }
 })
 
-export class TabContentComponent implements OnInit, AfterViewInit {
+export class TabContentComponent implements OnInit, AfterViewChecked {
   title;
   content: any = {};
   tabContent: any = [];
@@ -54,7 +54,7 @@ export class TabContentComponent implements OnInit, AfterViewInit {
           this.tabExist = false;
           this.tabContent = this.content.pageStructure[0];
         }
-
+        // For layout purpose
         if(this.content.url === 'foundation-typography') {
           this.typographyPage=true;
         }
@@ -68,15 +68,17 @@ export class TabContentComponent implements OnInit, AfterViewInit {
     });
 
   }
+
   ngOnInit() {
     const main = document.querySelector('main');
     this.wrapperTop = Math.round(main.getBoundingClientRect().top);
     document.querySelector('main').addEventListener('scroll', this.onScroll.bind(this));
   }
 
-  ngAfterViewInit()	{
-    const allTitles = document.querySelectorAll('h4.section-title');
+  ngAfterViewChecked(){
+    this.titleElements = [];
 
+    const allTitles = document.querySelectorAll('h4.section-title');
     allTitles.forEach((item) => {
       this.titleElements = [...this.titleElements, item.id]
     })

--- a/src/app/components/page/tab-content/tab-content.component.ts
+++ b/src/app/components/page/tab-content/tab-content.component.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 
 import { PageService } from 'src/app/app.service';
 import { Page } from 'src/app/app.interface';
@@ -21,11 +21,13 @@ export class TabContentComponent implements OnInit, AfterViewInit {
   tabExist: Boolean = false;
   typographyPage:Boolean = false;
   titleElements = [];
+  wrapperTop: number;
+  pageOffset = 144; // sticky nav height + padding
+  isAnchorActive: any;
 
   constructor(
     private route: ActivatedRoute,
-    public ps: PageService,
-    private router: Router
+    public ps: PageService
     ) {
 
     route.params.subscribe(params => this.title = params['id']);
@@ -67,27 +69,26 @@ export class TabContentComponent implements OnInit, AfterViewInit {
 
   }
   ngOnInit() {
-    const scrollWrapper = document.querySelector('main');
-
-    scrollWrapper.addEventListener('scroll', this.onScroll.bind(this));
-
+    const main = document.querySelector('main');
+    this.wrapperTop = Math.round(main.getBoundingClientRect().top);
+    document.querySelector('main').addEventListener('scroll', this.onScroll.bind(this));
   }
 
   ngAfterViewInit()	{
-    const allTitles = document.querySelectorAll('.section-title');
-    allTitles.forEach(title => {
-      this.titleElements.push({
-        id: title.id,
-        offset: title['offsetTop']
-      })
+    const allTitles = document.querySelectorAll('h4.section-title');
+
+    allTitles.forEach((item) => {
+      this.titleElements = [...this.titleElements, item.id]
     })
   }
 
   onScroll(e){
-    const pos = e.scrollTop;
+    const pos = Math.round(e.target.scrollTop);
+    
     this.titleElements.some(title => {
-      if(title.offset <= pos + 64){
-        console.log(title.id);
+      const offset = document.getElementById(title).offsetTop;
+      if(offset <= (pos - this.pageOffset)){
+        this.isAnchorActive = title;
       }
     })
   }
@@ -102,10 +103,7 @@ export class TabContentComponent implements OnInit, AfterViewInit {
     id = this.generateUrl(id);
     const elem = document.getElementById(id);
     const wrapper = document.querySelector('main');
-
-    const offset = 144; // sticky nav height + padding
-
-    wrapper.scroll({ top: (elem.getBoundingClientRect().top + wrapper.scrollTop - offset), left: 0, behavior: 'smooth' });
+    wrapper.scroll({ top: (elem.getBoundingClientRect().top + wrapper.scrollTop - this.pageOffset), left: 0, behavior: 'smooth' });
 
   }
 }

--- a/src/app/components/page/tab-content/tab-content.component.ts
+++ b/src/app/components/page/tab-content/tab-content.component.ts
@@ -79,19 +79,18 @@ export class TabContentComponent implements OnInit, AfterViewChecked {
     this.titleElements = [];
 
     const allTitles = document.querySelectorAll('h4.section-title');
+    let offset;
     allTitles.forEach((item) => {
-      this.titleElements = [...this.titleElements, item.id]
+      offset = item.getBoundingClientRect().top;
+      this.titleElements = [...this.titleElements, {id: item.id, offset: offset}]
     })
   }
 
   onScroll(e){
     const pos = Math.round(e.target.scrollTop);
     
-    this.titleElements.some(title => {
-      const offset = document.getElementById(title).offsetTop;
-      if(offset <= (pos - this.pageOffset)){
-        this.isAnchorActive = title;
-      }
+    this.titleElements.forEach(title => {
+      if(title.offset <= (pos - this.pageOffset)) this.isAnchorActive = title.id;
     })
   }
 

--- a/src/app/components/page/tab-content/tab-content.component.ts
+++ b/src/app/components/page/tab-content/tab-content.component.ts
@@ -1,5 +1,5 @@
-import { Component } from '@angular/core';
-import { ActivatedRoute, Router, Scroll } from '@angular/router';
+import { AfterViewInit, Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 
 import { PageService } from 'src/app/app.service';
 import { Page } from 'src/app/app.interface';
@@ -13,13 +13,14 @@ import { menus } from '../../../data/content.json';
   host: { class: 'tab-component-container' }
 })
 
-export class TabContentComponent {
+export class TabContentComponent implements OnInit, AfterViewInit {
   title;
   content: any = {};
   tabContent: any = [];
   defaultTab = '.';
   tabExist: Boolean = false;
   typographyPage:Boolean = false;
+  titleElements = [];
 
   constructor(
     private route: ActivatedRoute,
@@ -65,6 +66,32 @@ export class TabContentComponent {
     });
 
   }
+  ngOnInit() {
+    const scrollWrapper = document.querySelector('main');
+
+    scrollWrapper.addEventListener('scroll', this.onScroll.bind(this));
+
+  }
+
+  ngAfterViewInit()	{
+    const allTitles = document.querySelectorAll('.section-title');
+    allTitles.forEach(title => {
+      this.titleElements.push({
+        id: title.id,
+        offset: title['offsetTop']
+      })
+    })
+  }
+
+  onScroll(e){
+    const pos = e.scrollTop;
+    this.titleElements.some(title => {
+      if(title.offset <= pos + 64){
+        console.log(title.id);
+      }
+    })
+  }
+
 
   generateUrl(url){
     const generateUrlPipe = new GenerateTabURLPipe();


### PR DESCRIPTION
**Describe pull-request**  

Add active state on anchor menu

- If headlines scrolled into view, add active class on related anchor menu links
- Improvement on DOM detection has been implemented. Find all titles only after view changes, and not on scroll event.

**Solving issue**  
_Add which issue this pull-request solves by adding # plus the number of the issue (for example #123)_
Fixes: #166 

**How to test**  
1. On large screen, scroll page with anchors
2. See anchor link get active when title is on top of the view

**Screenshots**  
_If applicable, add screenshots to help explain_

**Additional context**  
Note: 
- Not really sure if anchor links has hover state? 
