### PR TITLE
AB#370 Render code from CMS for code tab 

### DIFF
--- a/fetchData.js
+++ b/fetchData.js
@@ -79,6 +79,7 @@ fragment detail on Content {
       title
       code
       componentTag
+      preview
     }
     ... on ComponentContentPluginOneColumn {
       id

--- a/src/app/components/code-example/code-example.component.html
+++ b/src/app/components/code-example/code-example.component.html
@@ -1,19 +1,12 @@
-<div *ngFor='let type of example.code | split:"\r?\n-\r?\n"'>
-  <div class="col-12">
-    <!-- Title -->
-    <h4 class="mb-5">{{example.title}}</h4>
-
-    <!-- Example -->
-    <!-- FIXME: set width of every component ?  -->
-
-    <div class='w-100 mb-5' [innerHTML]='type | keepHtml'></div>
-
-  <!-- Code  -->
-  <c-code-sample [innerHTML]='type | keepHtml'></c-code-sample>
-    
-</div>
+<section class="code-example-wrapper">
+  <ng-template [ngIf]="example.preview">
+    <h5 class="code-preview-title">{{example.title}}</h5>
+    <div class="code-preview" [innerHTML]="example.code | keepHtml"></div>
+  </ng-template>
+  <pre><code>{{example.code}}</code></pre>
+</section>
 
 <!-- If code-properties is empty don't show -->
 
-<div code-properties [currentComponent]='example' (change)='showProps($event)' [hidden]='emptyParent'></div>
+<!-- <div code-properties [currentComponent]='example' (change)='showProps($event)' [hidden]='emptyParent'></div> -->
 

--- a/src/app/components/code-example/code-example.component.scss
+++ b/src/app/components/code-example/code-example.component.scss
@@ -1,10 +1,12 @@
-c-code-sample {
-  margin: 0px 15px;
-}
+@import '~node_modules/@scania/typography/dist/scss/mixins';
+@import '~node_modules/@scania/typography/dist/scss/tokens';
 
-:host {
- > .row + div {
-   //FIXME: Depending how we will list component that are related we might wanna look more into this, button.disabled
-    margin-top: 60px;
+:host{
+  .code-preview{
+    margin-bottom: var(--sdds-spacing-element-16);
+    margin-top: var(--sdds-spacing-element-16);
+  }
+  .code-preview-title{
+    margin-top: var(--sdds-spacing-element-16);
   }
 }

--- a/src/app/components/code-example/code-example.component.ts
+++ b/src/app/components/code-example/code-example.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 
 @Component({
-  selector: '[code-example]',
+  selector: 'code-example',
   templateUrl:'code-example.component.html',
   styleUrls: ['code-example.component.scss']
 })

--- a/src/app/components/page/tab-content/tab-content.component.html
+++ b/src/app/components/page/tab-content/tab-content.component.html
@@ -39,9 +39,7 @@
 
         <!-- Code Example -->
         <ng-template [ngIf]="section.__typename === 'ComponentContentPluginCodeExample'">
-          <section class='code-example-wrapper no-padding sdds-col-xxlg-9 sdds-col-xlg-11 sdds-col-lg-6 sdds-col-md-8 sdds-col-sm-4' >
-            <pre><code>{{section.code}}</code></pre>
-          </section>
+          <code-example [example]="section" class="no-padding sdds-col-xxlg-9 sdds-col-xlg-11 sdds-col-lg-6 sdds-col-md-8 sdds-col-sm-4"></code-example>
         </ng-template>
 
         <!-- One column -->


### PR DESCRIPTION
- Use code example component in website
- Styles are implemented generally  not in the component, because some content from CMS use <pre> inside "one-column" component

How to test
- Check together with https://github.com/scania-digital-design-system/sdds-cms/pull/32
- Add content in CMS with the "preview" option set to true in local CMS

Additional notes:

- Need to add latest @scania/components & @scania/theme-light to get correct styling for buttons and so on
- When using latest component and theme package, need to import global-style and fix classes for checkbox, links in footer, buttons, etc, and check the whole page again.

